### PR TITLE
Use unix socket to connect to Docker API

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -169,7 +169,7 @@ shutdown stateVar exitFlag = do
       _ -> return state
     
   -- kill containers
-  httpHandler <- Docker.defaultHttpHandler
+  httpHandler <- dockerDefaultUnixHandler
   state <- readMVar stateVar
   Docker.runDockerT (Docker.defaultClientOpts { Docker.baseUrl = "http://127.0.0.1:2376" } , httpHandler) $
     for_ (State.containerIds state) stopAndRemove


### PR DESCRIPTION
On Mac it's currently impossible to configure Docker to listen on tcp
address, which forces to use clumsy solutons like
https://forums.docker.com/t/using-pycharm-docker-plugin-with-docker-beta/8617/10