### PR TITLE
Gracefully handle sigINT and sigTERM

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,14 +13,16 @@ import Control.Monad.IO.Class (liftIO)
 import qualified Data.Text as Text
 import qualified Data.List as List
 import qualified Network.WebSockets as WebSocket
-import           Control.Exception (IOException, catch)
+import           Control.Exception (catch)
 import           Control.Concurrent.Suspend.Lifted (msDelay, suspend)
 import           Control.Monad (forever, when)
 import qualified Data.Aeson as Aeson
 import qualified Data.Maybe as Maybe
-import           Control.Concurrent (MVar, newMVar, takeMVar, putMVar, readMVar)
-import           Control.Concurrent.Async (async, wait)
+import           Control.Concurrent (MVar, newMVar, newEmptyMVar, takeMVar, putMVar, readMVar, modifyMVar_)
+import           Control.Concurrent.Async (async)
 import           Data.Foldable (for_)
+import           System.Posix.Signals       (Handler (CatchOnce),
+                                             installHandler, sigINT, sigTERM)
 
 
 import HexFile (HexFile(HexFile),
@@ -37,19 +39,16 @@ import ServiceIdentity (ServiceType(ContainerService),
 import State (State)
 import qualified State
 
-app :: MVar State -> HexFile -> String -> Int -> WebSocket.ClientApp ()
-app stateVar hexFile messengerHost messengerPort connection = do
+app :: MVar State -> HexFile -> IO () -> WebSocket.ClientApp ()
+app stateVar hexFile shutdownHandler connection = do
+  -- save connection
+  modifyMVar_ stateVar $ return . (State.setConnecton connection)
+ 
   catch
     (WebSocket.sendTextData connection $ Aeson.encode $ Envelope Messenger (CheckIn ContainerService))
     (\exception -> putStrLn $ "Whoa " <> show (exception :: WebSocket.ConnectionException))
   forever $ do
-    string <- catch
-      (WebSocket.receiveData connection)
-      (\exception -> do
-        putStrLn $ "Error while receiving data" <> show (exception :: WebSocket.ConnectionException)
-        suspend $ msDelay 500
-        connectToMessenger messengerHost messengerPort $ app stateVar hexFile messengerHost messengerPort
-        return "")
+    string <- WebSocket.receiveData connection
     case Aeson.eitherDecode string :: Either String (Envelope IncomingMessage) of
       Left err -> putStrLn err
       Right Envelope{message} ->
@@ -80,29 +79,29 @@ app stateVar hexFile messengerHost messengerPort connection = do
                   Envelope (Service identity) (ServiceRequestFulfilled serviceIdentity)
               Nothing -> putMVar stateVar state
 
-          Shutdown -> do
-            WebSocket.sendClose connection ("Hex is shutting down. See ya, Arnaux" :: Text.Text)
-            state <- readMVar stateVar
-            httpHandler <- Docker.defaultHttpHandler
-            Docker.runDockerT (Docker.defaultClientOpts { Docker.baseUrl = "http://127.0.0.1:2376" } , httpHandler) $
-              for_ (State.containerIds state) stopAndRemove
-                where
-                  stopAndRemove containerId = do
-                    Docker.stopContainer Docker.DefaultTimeout containerId
-                    result <- Docker.deleteContainer Docker.defaultDeleteOpts containerId
-                    case result of
-                      Right _  -> liftIO $ putStrLn $ "Cleaned up successfully: " <> show containerId
-                      Left err -> liftIO $ print err
-
-connectToMessenger :: String -> Int -> WebSocket.ClientApp () -> IO ()
-connectToMessenger messengerHost messengerPort clientApp =
+          Shutdown -> async shutdownHandler >> pure ()
+            
+connectToMessenger :: MVar State -> String -> Int -> WebSocket.ClientApp () -> IO ()
+connectToMessenger stateVar messengerHost messengerPort clientApp =
   catch
     (WebSocket.runClient messengerHost messengerPort "/" clientApp)
-    (\exception -> do
-      putStrLn $ "Connection to messenger lost: " <> show (exception :: WebSocket.ConnectionException)
+    exceptionHandler
+  where
+    exceptionHandler e@(WebSocket.CloseRequest _ _) = reconnectUnlessShutdown e
+    exceptionHandler e@(WebSocket.ConnectionClosed) = reconnectUnlessShutdown e
+    exceptionHandler e = reconnect e
+
+    reconnectUnlessShutdown exception = do
+      ws <- State.websocket <$> readMVar stateVar
+      case ws of
+        State.ConnectionClosed -> return ()
+        _ -> reconnect exception
+
+    reconnect exception = do
+      putStrLn $ "Websocket error: " <> show (exception :: WebSocket.ConnectionException)
       suspend $ msDelay 500
       putStrLn "Reconnecting..."
-      connectToMessenger messengerHost messengerPort clientApp)
+      connectToMessenger stateVar messengerHost messengerPort clientApp
 
 runServiceContainer :: MVar State -> ServiceDefinition -> Docker.DockerT IO (Either Docker.DockerError ())
 runServiceContainer stateVar (ServiceDefinition name imageName buildContext _ createOptions) = do
@@ -153,8 +152,62 @@ stopAndRemove (ServiceDefinition _ name buildContext buildOptions _) = do
             Left err -> liftIO $ print err
         Nothing -> return ()
 
+-- TODO: some long-running operations such as building or pulling docker image may need special care
+-- TODO: handle exceptions in main thread
+shutdown :: MVar State -> ExitFlag -> IO ()
+shutdown stateVar exitFlag = do
+  putStrLn "Shutting down..."
+
+  -- close websocket connection
+  modifyMVar_ stateVar $ \state -> do
+    case State.websocket state of
+      State.Connected connection -> do
+        WebSocket.sendClose connection ("Hex is shutting down. See ya, Arnaux" :: Text.Text)
+        return $ State.setConnectionClosed state
+      _ -> return state
+    
+  -- kill containers
+  httpHandler <- Docker.defaultHttpHandler
+  state <- readMVar stateVar
+  Docker.runDockerT (Docker.defaultClientOpts { Docker.baseUrl = "http://127.0.0.1:2376" } , httpHandler) $
+    for_ (State.containerIds state) stopAndRemove
+  putStrLn "All containers have been stopped!"
+
+  -- tell the main thread that it's time to exit
+  setExitFlag exitFlag
+  where
+    stopAndRemove containerId = do
+      liftIO $ putStrLn $ "Stopping container " <> show containerId <> "..."
+      Docker.stopContainer Docker.DefaultTimeout containerId
+      liftIO $ putStrLn $ "Stopped successfully, now removing the container " <> show containerId <> "..."
+      result <- Docker.deleteContainer Docker.defaultDeleteOpts containerId
+      case result of
+        Left err -> liftIO $ print err
+        -- TODO: remove containerId from State after successfull cleanup
+        Right _  -> liftIO $ putStrLn $ "Cleaned up successfully: " <> show containerId
+
+setupInterruptionHandlers :: IO () -> IO Handler
+setupInterruptionHandlers handler = do
+  installHandler sigINT (CatchOnce handler) Nothing
+  installHandler sigTERM (CatchOnce handler) Nothing
+
+type ExitFlag = MVar ()
+
+newExitFlag :: IO (MVar ())
+newExitFlag = newEmptyMVar
+
+setExitFlag :: MVar () -> IO ()
+setExitFlag flag = putMVar flag ()
+
+waitForExitFlag :: MVar () -> IO ()
+waitForExitFlag = takeMVar
+
 main :: IO ()
 main = do
+  stateVar <- newMVar State.empty
+  exitFlag <- newExitFlag
+  let shutdownHandler = shutdown stateVar exitFlag
+  setupInterruptionHandlers shutdownHandler
   decodedHexFile <- Yaml.decodeFileEither "./Hexfile.yml" :: IO (Either ParseException HexFile)
   case decodedHexFile of
     Right hexFile@(HexFile services (MessengerDefinition messengerName messengerPort) initSequence) -> do
@@ -163,11 +216,10 @@ main = do
         case Map.lookup messengerName services of
           Nothing -> fail $ "Messenger service " <> show messengerName <> " is not defined"
           Just messengerDefinition@(ServiceDefinition name imageName buildContext buildOptions createOptions) -> do
-            stateVar <- liftIO $ newMVar State.empty
             ensureBuiltImage messengerDefinition
             runServiceContainer stateVar messengerDefinition
             let messengerHost = "localhost"
-            wsClient <- liftIO $ async $ connectToMessenger messengerHost messengerPort $ app stateVar hexFile messengerHost messengerPort
+            wsClient <- liftIO $ async $ connectToMessenger stateVar messengerHost messengerPort $ app stateVar hexFile shutdownHandler
             for_ initSequence $ \serviceName ->
               case Map.lookup serviceName services of
                 Just entryServiceDefinition -> do
@@ -175,6 +227,6 @@ main = do
                   runServiceContainer stateVar entryServiceDefinition
                 Nothing -> fail $ "Init sequence: service " <> show serviceName <> " is not defined"
 
-            liftIO $ wait wsClient
-
     Left err -> putStrLn $ "Error reading Hexfile: " <> show err
+
+  waitForExitFlag exitFlag

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -190,13 +190,13 @@ setupInterruptionHandlers handler = do
 
 type ExitFlag = MVar ()
 
-newExitFlag :: IO (MVar ())
+newExitFlag :: IO ExitFlag
 newExitFlag = newEmptyMVar
 
-setExitFlag :: MVar () -> IO ()
+setExitFlag :: ExitFlag -> IO ()
 setExitFlag flag = putMVar flag ()
 
-waitForExitFlag :: MVar () -> IO ()
+waitForExitFlag :: ExitFlag -> IO ()
 waitForExitFlag = takeMVar
 
 main :: IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -152,8 +152,6 @@ stopAndRemove (ServiceDefinition _ name buildContext buildOptions _) = do
             Left err -> liftIO $ print err
         Nothing -> return ()
 
--- TODO: some long-running operations such as building or pulling docker image may need special care
--- TODO: handle exceptions in main thread
 shutdown :: MVar State -> ExitFlag -> IO ()
 shutdown stateVar exitFlag = do
   putStrLn "Shutting down..."
@@ -183,7 +181,6 @@ shutdown stateVar exitFlag = do
       result <- Docker.deleteContainer Docker.defaultDeleteOpts containerId
       case result of
         Left err -> liftIO $ print err
-        -- TODO: remove containerId from State after successfull cleanup
         Right _  -> liftIO $ putStrLn $ "Cleaned up successfully: " <> show containerId
 
 setupInterruptionHandlers :: IO () -> IO Handler

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,6 +3,7 @@
 
 module Main where
 
+import Data.Functor (($>))
 import Data.Yaml as Yaml
 import qualified Docker.Client as Docker
 import Docker.Client.Types (Image(DockerImage))
@@ -79,7 +80,7 @@ app stateVar hexFile shutdownHandler connection = do
                   Envelope (Service identity) (ServiceRequestFulfilled serviceIdentity)
               Nothing -> putMVar stateVar state
 
-          Shutdown -> async shutdownHandler >> pure ()
+          Shutdown -> async shutdownHandler $> ()
             
 connectToMessenger :: MVar State -> String -> Int -> WebSocket.ClientApp () -> IO ()
 connectToMessenger stateVar messengerHost messengerPort clientApp =

--- a/hex.cabal
+++ b/hex.cabal
@@ -33,6 +33,7 @@ library
                      , docker -any
                      , uuid -any
                      , unordered-containers -any
+                     , websockets
   default-language:    Haskell2010
 
 executable hex-exe
@@ -52,6 +53,7 @@ executable hex-exe
                      , suspend
                      , aeson
                      , async
+                     , unix
   default-language:    Haskell2010
 
 test-suite hex-test


### PR DESCRIPTION
Stop and remove all started containers upon receiving termination
request.

Because termination handler runs in another thread (as decribed in
http://hackage.haskell.org/package/unix-2.7.2.2/docs/System-Posix-Signals.html#v:installHandler)
and needs a bit of time to stop all containers, we need a way to tell
main thread to wait until cleanup is finished. Otherwise, main thread
will exit too early, and termination handler thread will be killed, not
able to finish cleanup. Communication with main thread is done using
`MVar` as a flag, because `takeMVar` will wait until `MVar` is filled
with value. For better clarity this `MVar` is aliased as `ExitFlag`.

Closing websocket connection poses another challenge, because
termination handler needs access to connection to be able to close it,
so connection now lives in global `State`.

`connectToMessenger` behavior is altered in a way that it recognzes that
connection is being closed, and doesn't attempt to reconnect.

Error handling in the `app` function is removed, because anyway `app`
runs inside `connectToMessenger`, so it can catch errors, and it turned
out that `ConnectionClosed` exceptions have to be handled there to stop
reconnection attempts.

Closes #4