### PR TITLE
Volumes (bind mounts) support

### DIFF
--- a/Hexfile.yml
+++ b/Hexfile.yml
@@ -15,9 +15,7 @@ services:
     ports:
       - "27020:27017"
     volumes:
-      - type: volume
-        source: ./mongo-logs
-        target: /data/db
+      - ./mongo-logs:/data/db
   -
     name: messenger
     context: ../qd-platform/arnaux
@@ -34,9 +32,7 @@ services:
     name: front-service
     context: ../qd-platform/front-service
     volumes:
-      - type: volume
-        source: ./front-service/logs
-        target: /front-end-service/logs
+      - ./front-service/logs:/front-end-service/logs
     environment:
       - DB_URI=mongodb://mongo-front-service/fe-db
       - ARNAUX_URL=ws://messenger:3000

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,6 @@
 module Main where
 
 import Data.Functor (($>))
-import Data.Yaml as Yaml
 import qualified Data.HashMap.Strict as HashMap
 import qualified Docker.Client as Docker
 import Docker.Client.Types (Image(DockerImage))
@@ -27,6 +26,7 @@ import           System.Posix.Signals       (Handler (CatchOnce),
                                              installHandler, sigINT, sigTERM)
 
 
+import qualified HexFile
 import HexFile (HexFile(HexFile),
                 services,
                 ServiceDefinition(ServiceDefinition),
@@ -220,7 +220,7 @@ main = do
   exitFlag <- newExitFlag
   let shutdownHandler = shutdown stateVar exitFlag
   setupInterruptionHandlers shutdownHandler
-  decodedHexFile <- Yaml.decodeFileEither "./Hexfile.yml" :: IO (Either ParseException HexFile)
+  decodedHexFile <- HexFile.decode "./Hexfile.yml"
   case decodedHexFile of
     Right hexFile@(HexFile services (MessengerDefinition messengerName messengerPort) initSequence) -> do
       httpHandler <- Docker.defaultHttpHandler

--- a/hex.cabal
+++ b/hex.cabal
@@ -34,6 +34,7 @@ library
                      , uuid -any
                      , unordered-containers -any
                      , websockets
+                     , directory
   default-language:    Haskell2010
 
 executable hex-exe

--- a/src/HexFile.hs
+++ b/src/HexFile.hs
@@ -3,14 +3,15 @@
 
 module HexFile where
 
-import Data.Text (Text, splitOn, unpack)
+import Data.Text (Text, splitOn, unpack, pack)
 import Data.Map.Strict (Map)
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map.Strict as Map
 import Docker.Client (BuildOpts, defaultBuildOpts,
                       CreateOpts(CreateOpts), defaultCreateOpts,
-                      HostConfig, portBindings, networkMode, defaultHostConfig,
+                      HostConfig(HostConfig), portBindings, networkMode, binds, hostConfig, defaultHostConfig,
                       NetworkMode(NetworkNamed),
+                      Bind(Bind), hostSrc,
                       Port,
                       PortBinding(PortBinding), containerPort, portType, hostPorts,
                       HostPort(HostPort),
@@ -24,6 +25,35 @@ import Docker.Client (BuildOpts, defaultBuildOpts,
 import Data.Aeson (FromJSON(parseJSON), (.:), (.:?), (.!=), Value(Object, String))
 import Control.Monad (mzero)
 import Data.Semigroup ((<>))
+import Data.Yaml as Yaml
+import System.Directory (makeAbsolute)
+import Control.Exception (catch)
+
+decode :: FilePath -> IO (Either ParseException HexFile)
+decode file = do
+  result <- Yaml.decodeFileEither file
+  case result of
+    Right hexFile -> preprocess hexFile
+    Left e -> return $ Left e
+
+preprocess :: HexFile -> IO (Either ParseException HexFile)
+preprocess hexFile =
+  catch
+    (fmap Right . updateHostSrcs makeAbsolutePath $ hexFile)
+    (return . Left . OtherParseException)
+  where
+    makeAbsolutePath = fmap pack . makeAbsolute . unpack
+    updateHostSrcs =
+      updateServices . traverse
+        . updateCreateOptions
+        . updateHostConfig
+        . updateBinds . traverse
+        . updateHostSrc
+    updateServices f s      = (\a -> s { services = a })      <$> f (services s)
+    updateCreateOptions f s = (\a -> s { createOptions = a }) <$> f (createOptions s)
+    updateHostConfig f s    = (\a -> s { hostConfig = a })    <$> f (hostConfig s)
+    updateBinds f s         = (\a -> s { binds = a })         <$> f (binds s)
+    updateHostSrc f s       = (\a -> s { hostSrc = a })       <$> f (hostSrc s)
 
 type ServiceName = Text
 
@@ -92,6 +122,7 @@ instance FromJSON ServiceDefinition where
 
     portMappings <- definition .:? "ports" .!= []
     envVars <- definition .:? "environment" .!= []
+    volumeMappings <- definition .:? "volumes" .!= []
 
     let hexName       = getHexName name
         imageName     = case buildContext of
@@ -100,8 +131,10 @@ instance FromJSON ServiceDefinition where
         buildOptions  = defaultBuildOpts hexName
         createOptions = let portBindings    = mappingToBinding <$> portMappings
                             exposedPorts    = mappingToExposedPort <$> portMappings
+                            binds           = volumeMappings -- not all volumes are binds, but for now we support only binds
                             hostConfig      = defaultHostConfig
                                                 { portBindings
+                                                , binds
                                                 , networkMode = NetworkNamed "hex-network"
                                                 }
                             containerConfig = (defaultContainerConfig imageName)

--- a/src/HexFile.hs
+++ b/src/HexFile.hs
@@ -25,7 +25,8 @@ import Docker.Client (BuildOpts, defaultBuildOpts,
 import Data.Aeson (FromJSON(parseJSON), (.:), (.:?), (.!=), Value(Object, String))
 import Control.Monad (mzero)
 import Data.Semigroup ((<>))
-import Data.Yaml as Yaml
+import qualified Data.Yaml as Yaml
+import Data.Yaml as Yaml (ParseException(OtherParseException))
 import System.Directory (makeAbsolute)
 import Control.Exception (catch)
 


### PR DESCRIPTION
We actually use `volumes` section to declare [bind mounts](https://docs.docker.com/storage/bind-mounts/) (`docker-compose.yml`-style [mixes up all kinds on volumes here](https://docs.docker.com/compose/compose-file/#long-syntax-3)), so only this functionality is supported for now.

Volume declarations in `Hexfile.yml` are changed to short syntax, that way we can reuse `FromJSON` instances for `Bind` declared in `docker-hs`.

Closes #7 