### PR TITLE
Use named volumes instead of bind mounts

### DIFF
--- a/Hexfile.yml
+++ b/Hexfile.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "27020:27017"
     volumes:
-      - ./mongo-logs:/data/db
+      - mongo-logs:/data/db
   -
     name: messenger
     context: ../qd-platform/arnaux
@@ -32,7 +32,7 @@ services:
     name: front-service
     context: ../qd-platform/front-service
     volumes:
-      - ./front-service/logs:/front-end-service/logs
+      - front-end-logs:/front-end-service/logs
     environment:
       - DB_URI=mongodb://mongo-front-service/fe-db
       - ARNAUX_URL=ws://messenger:3000


### PR DESCRIPTION
It turns out to be impossible to use bind mounts when `hex` itself is running inside Docker container, because when you take a relative path from `Hexfile.yml` and try to convert it to absolute path, you end up with absolute path *inside `hex`'s container*. This absolute path is then sent to Docker, and because this path doesn't exist on host machine, Docker will fail with error.

So here, to resolve this problem, we use ["volumes"](https://docs.docker.com/storage/volumes/) feature of Docker, and those volumes are managed by Docker itself, so we don't have to worry about anything.

Volumes are persisted between container stops/removals, and they have mnemonic names, so it's easy to mount them to one-off container and inspect their content (volume name here is `mongo-logs`):
```$ docker run -it --rm --mount source=mongo-logs,target=/mongo-logs alpine /bin/ash```